### PR TITLE
Fix the error: 'toy' not found

### DIFF
--- a/scripts/socialcircle_toy_example.py
+++ b/scripts/socialcircle_toy_example.py
@@ -60,7 +60,7 @@ class BetaToyExample():
             self.t = t
             self.init_model()
             self.t.log(
-                f'Model `{toy.t.args.loada}` and dataset files ({CLIP}) loaded.')
+                f'Model `{t.args.loada}` and dataset files ({CLIP}) loaded.')
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
Fixed the error where variable 'toy' was not found while running the following command:
`python scripts/socialcircle_toy_example.py`